### PR TITLE
An update and fix

### DIFF
--- a/commentsrating/services/CommentsRatingService.php
+++ b/commentsrating/services/CommentsRatingService.php
@@ -19,17 +19,41 @@ class CommentsRatingService extends BaseApplicationComponent
 	*/
     public function createRating($comment)
     {
+        $commentRatingRecord = CommentsRatingRecord::model()->findByAttributes(
+            array(
+                'commentId' => $comment->id
+            )
+        );
+                            
+        if ($commentRatingRecord) {
+            $this->updateRating($comment, $commentRatingRecord);
+        }
+        else
+        {
+            $model = new CommentsRatingModel();
+            $model->commentId = $comment->id;
+            $model->elementId = $comment->elementId;
+            $model->userId = $comment->userId;
+            $model->rating = craft()->request->getPost('fields.commentsRating');
+            
+            $commentRatingRecord = new CommentsRatingRecord;
+            $commentRatingRecord->setAttributes($model->getAttributes());
+            $commentRatingRecord->save();
+        }
+        
+    }
+
+    /**
+	 * Rating - Update
+	 *
+	 * @return null
+	*/
+    public function updateRating($comment, $commentRatingRecord)
+    {
 	    
-        $model = new CommentsRatingModel();
-	    $model->commentId = $comment->id;
-	    $model->elementId = $comment->elementId;
-	    $model->userId = $comment->userId;
-	    $model->rating = craft()->request->getPost('fields.commentsRating');
-	    
-		$commentRatingRecord = new CommentsRatingRecord;
-		$commentRatingRecord->setAttributes($model->getAttributes());
-		$commentRatingRecord->save();
-	    
+		$commentRatingRecord->rating = craft()->request->getPost('fields.commentsRating');
+        $commentRatingRecord->save();
+        
     }
     
 	/**
@@ -66,7 +90,8 @@ class CommentsRatingService extends BaseApplicationComponent
 			->where('elementId=' . $elementId)
 			->queryAll();
 		
-		return (count($query) == 0) ? 0 : round($query[0]['average']);
+        //return (count($query) == 0) ? 0 : round($query[0]['average']);
+		return (count($query) == 0) ? 0 : round($query[0]['average'] *2) / 2;
 	    
     }
     

--- a/commentsrating/services/CommentsRatingService.php
+++ b/commentsrating/services/CommentsRatingService.php
@@ -90,7 +90,6 @@ class CommentsRatingService extends BaseApplicationComponent
 			->where('elementId=' . $elementId)
 			->queryAll();
 		
-        //return (count($query) == 0) ? 0 : round($query[0]['average']);
 		return (count($query) == 0) ? 0 : round($query[0]['average'] *2) / 2;
 	    
     }


### PR DESCRIPTION
Updated the rating to return half star ratings. Fixed an issue where editing an exit comments rating would create a duplicate rating entry in the database. This would artificially inflate or drop an entries rating. The fix  checks if a comment has an existing rating and then updates that rating instead.